### PR TITLE
Add support for `async` polling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Added
 
-- n/a
+- Added support for async-await (via optional `async` crate feature):
+  - Added `async fn poll_async()` method to `IncrementalEncoder<…>`.
+  - Added `async fn poll_async()` method to `IndexedIncrementalEncoder<…>`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Added
 
-- Added support for async-await (via optional `async` crate feature):
-  - Added `async fn poll_async()` method to `IncrementalEncoder<…>`.
-  - Added `async fn poll_async()` method to `IndexedIncrementalEncoder<…>`.
+- Added support for async-await (via `async` crate feature, enabled by default):
+  - Added `fn into_async()` method to `IncrementalEncoder<…>`, which returns an async version of the encoder, whose `poll()` method can be `.await`-ed.
+  - Added `fn into_async()` method to `IndexedIncrementalEncoder<…>`, which returns an async version of the encoder, whose `poll()` method can be `.await`-ed.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/quadrature"
 license = "MPL-2.0"
 edition = "2021"
 version = "0.1.1"
-rust-version = "1.74.1"
+rust-version = "1.75"
 
 [workspace.dependencies]
 num-traits = { version = "0.2.19", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/regexident/quadrature"
 documentation = "https://docs.rs/quadrature"
 license = "MPL-2.0"
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 rust-version = "1.74.1"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/regexident/quadrature"
 documentation = "https://docs.rs/quadrature"
 license = "MPL-2.0"
 edition = "2021"
-version = "0.1.2"
+version = "0.1.1"
 rust-version = "1.74.1"
 
 [workspace.dependencies]

--- a/quadrature-decoder/CHANGELOG.md
+++ b/quadrature-decoder/CHANGELOG.md
@@ -20,13 +20,11 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Added
 
-- Added support for async-await (via `async` crate feature, enabled by default):
-  - Added `fn into_async()` method to `IncrementalEncoder<…>`, which returns an async version of the encoder, whose `poll()` method can be `.await`-ed.
-  - Added `fn into_async()` method to `IndexedIncrementalEncoder<…>`, which returns an async version of the encoder, whose `poll()` method can be `.await`-ed.
+- n/a
 
 ### Changed
 
-- n/a
+- Bumped MSRV from `1.74.1` to `1.75.0`.
 
 ### Deprecated
 

--- a/quadrature-encoder/CHANGELOG.md
+++ b/quadrature-encoder/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please make sure to add your changes to the appropriate categories:
+
+- `Added`: for new functionality
+- `Changed`: for changes in existing functionality
+- `Deprecated`: for soon-to-be removed functionality
+- `Removed`: for removed functionality
+- `Fixed`: for fixed bugs
+- `Performance`: for performance-relevant changes
+- `Security`: for security-relevant changes
+- `Other`: for everything else
+
+## [Unreleased]
+
+### Added
+
+- Added support for async-await (via `async` crate feature, enabled by default):
+  - Added trailing generic parameter `PollMode` to `IncrementalEncoder<…>` and `IndexedIncrementalEncoder<…>` to support both, blocking and async polling modes:
+    - `IncrementalEncoder<…, Blocking>`, which exposes its `fn poll()` as a blocking method.
+    - `IndexedIncrementalEncoder<…, Blocking>`, which exposes its `fn poll()` as a blocking method.
+    - `IncrementalEncoder<…, Async>`, which exposes its `fn poll()` as an `async` method.
+    - `IndexedIncrementalEncoder<…, Async>`, which exposes its `fn poll()` as an `async` method.
+  - Added `fn into_async()` and `fn into_blocking()` methods for converting between blocking and non-blocking poll modes:
+    - `fn into_async()`, which converts `IncrementalEncoder<…, Blocking>` into its non-blocking equivalent: `IncrementalEncoder<…, Async>`.
+    - `fn into_async()`, which converts `IndexedIncrementalEncoder<…, Blocking>` into its non-blocking equivalent: `IndexedIncrementalEncoder<…, Async>`.
+    - `fn into_blocking()`, which converts `IncrementalEncoder<…, Async>` back into its blocking equivalent: `IncrementalEncoder<…, Blocking>`.
+    - `fn into_blocking()`, which converts `IndexedIncrementalEncoder<…, Async>` back into its blocking equivalent: `IndexedIncrementalEncoder<…, Blocking>`.
+
+### Changed
+
+- Changed generic parameters of `IncrementalEncoder<…>` to `<Mode, Clk, Dt, Steps, T, PM>`, adding trailing `PM` parameter.
+- Changed generic parameters of `IndexedIncrementalEncoder<…>` to `<Mode, Clk, Dt, Idx, Steps, T, PM>`, adding trailing `PM` parameter.
+
+### Deprecated
+
+- n/a
+
+### Removed
+
+- n/a
+
+### Fixed
+
+- n/A
+
+### Performance
+
+- n/a
+
+### Security
+
+- n/a
+
+### Other
+
+- n/a
+
+## [0.1.1] - 2024-06-05
+
+### Changed
+
+- Bumped MSRV from `1.74.0` to `1.74.1`
+
+## [0.1.0] - 2024-05-21
+
+Initial release.

--- a/quadrature-encoder/CHANGELOG.md
+++ b/quadrature-encoder/CHANGELOG.md
@@ -36,6 +36,7 @@ Please make sure to add your changes to the appropriate categories:
 
 - Changed generic parameters of `IncrementalEncoder<…>` to `<Mode, Clk, Dt, Steps, T, PM>`, adding trailing `PM` parameter.
 - Changed generic parameters of `IndexedIncrementalEncoder<…>` to `<Mode, Clk, Dt, Idx, Steps, T, PM>`, adding trailing `PM` parameter.
+- Bumped MSRV from `1.74.1` to `1.75.0`.
 
 ### Deprecated
 

--- a/quadrature-encoder/Cargo.toml
+++ b/quadrature-encoder/Cargo.toml
@@ -15,9 +15,19 @@ version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = { version = "1.0.0" }
+eh1 = { package = "embedded-hal", version = "1.0", optional = true }
+eh0 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"], optional = true }
+embedded-hal-async = { version = "1.0", optional = true }
 num-traits = { workspace = true }
 quadrature-decoder = { version = "0.1.1", path = "../quadrature-decoder", default-features = false }
+futures = { version = "0.3.31", default-features = false, optional = true }
+embassy-futures = "0.1.1"
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.11.0", features = ["eh1"] }
+embedded-hal-mock = { version = "0.11.0", features = ["eh0","eh1","embedded-hal-async"] }
+
+[features]
+eh1 = ["dep:eh1"] # use Pin traits from embedded-hal v1.0.0
+eh0 = ["dep:eh0"] # use Pin traits from embedded-hal v0.2.7
+async = ["dep:embedded-hal-async", "dep:futures"] # enables poll_async(). requires Wait trait for pins, such as those wrapped by ExtInt<EicPin<...>>.
+default = ["eh1"]

--- a/quadrature-encoder/Cargo.toml
+++ b/quadrature-encoder/Cargo.toml
@@ -15,19 +15,36 @@ version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eh1 = { package = "embedded-hal", version = "1.0", optional = true }
-eh0 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"], optional = true }
-embedded-hal-async = { version = "1.0", optional = true }
 num-traits = { workspace = true }
 quadrature-decoder = { version = "0.1.1", path = "../quadrature-decoder", default-features = false }
+embedded-hal-compat = { version = "0.13.0" }
+embedded-hal-async = { version = "1.0", optional = true }
 futures = { version = "0.3.31", default-features = false, optional = true }
-embassy-futures = "0.1.1"
+embassy-futures = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.0", features = ["eh0","eh1","embedded-hal-async"] }
 
 [features]
-eh1 = ["dep:eh1"] # use Pin traits from embedded-hal v1.0.0
-eh0 = ["dep:eh0"] # use Pin traits from embedded-hal v0.2.7
-async = ["dep:embedded-hal-async", "dep:futures"] # enables poll_async(). requires Wait trait for pins, such as those wrapped by ExtInt<EicPin<...>>.
-default = ["eh1"]
+default = ["async"]
+async = ["dep:embedded-hal-async", "dep:futures", "dep:embassy-futures"] # provides an async poll() implimentation
+
+[[example]]
+name = "rotary"
+
+[[example]]
+name = "linear"
+
+[[example]]
+name = "rotary_eh0"
+
+[[example]]
+name = "linear_eh0"
+
+[[example]]
+name = "rotary_async"
+required-features = ["async"]
+
+[[example]]
+name = "linear_async"
+required-features = ["async"]

--- a/quadrature-encoder/Cargo.toml
+++ b/quadrature-encoder/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "quadrature-encoder"
 description = "Hardware-level implementations of drivers for incremental encoders with support for full-, half- an quad-stepping."
-keywords = ["quadrature-encoder", "incremental-encoder", "rotary-encoder", "linear-encoder"]
+keywords = [
+    "quadrature-encoder",
+    "incremental-encoder",
+    "rotary-encoder",
+    "linear-encoder",
+]
 categories = ["embedded", "no-std"]
 
 repository = { workspace = true }
@@ -23,11 +28,19 @@ futures = { version = "0.3.31", default-features = false, optional = true }
 embassy-futures = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.11.0", features = ["eh0","eh1","embedded-hal-async"] }
+embedded-hal-mock = { version = "0.11.0", features = [
+    "eh0",
+    "eh1",
+    "embedded-hal-async",
+] }
 
 [features]
 default = ["async"]
-async = ["dep:embedded-hal-async", "dep:futures", "dep:embassy-futures"] # provides an async poll() implementation
+async = [
+    "dep:embedded-hal-async",
+    "dep:futures",
+    "dep:embassy-futures",
+] # provides an async poll() implementation
 
 [[example]]
 name = "rotary"

--- a/quadrature-encoder/Cargo.toml
+++ b/quadrature-encoder/Cargo.toml
@@ -27,7 +27,7 @@ embedded-hal-mock = { version = "0.11.0", features = ["eh0","eh1","embedded-hal-
 
 [features]
 default = ["async"]
-async = ["dep:embedded-hal-async", "dep:futures", "dep:embassy-futures"] # provides an async poll() implimentation
+async = ["dep:embedded-hal-async", "dep:futures", "dep:embassy-futures"] # provides an async poll() implementation
 
 [[example]]
 name = "rotary"

--- a/quadrature-encoder/README.md
+++ b/quadrature-encoder/README.md
@@ -61,15 +61,15 @@ See the examples directory for a more comprehensive example.
 
 ## Convenience Aliases
 
-Since the full typename `IncrementalEncoder<Mode, ..., Step, T>` can be quite a mouth-full a couple of convenience type-aliases are provided for the most common use-cases:
+Since the full typename `IncrementalEncoder<Mode, ..., Step, T, PM>` can be quite a mouth-full a couple of convenience type-aliases are provided for the most common use-cases:
 
 ### Rotary Encoders
 
 ```rust
 use quadrature_encoder::{RotaryEncoder, IndexedRotaryEncoder};
 
-let mut encoder: RotaryEncoder::new(pin_clk, pin_dt);
-let mut indexed_encoder: IndexedRotaryEncoder::new(pin_clk, pin_dt, pin_idx);
+let mut encoder = RotaryEncoder::new(pin_clk, pin_dt);
+let mut indexed_encoder = IndexedRotaryEncoder::new(pin_clk, pin_dt, pin_idx);
 ```
 
 ### Linear Encoders
@@ -77,8 +77,33 @@ let mut indexed_encoder: IndexedRotaryEncoder::new(pin_clk, pin_dt, pin_idx);
 ```rust
 use quadrature_encoder::{LinearEncoder, IndexedLinearEncoder};
 
-let mut encoder: LinearEncoder::new(pin_clk, pin_dt);
-let mut indexed_encoder: IndexedLinearEncoder::new(pin_clk, pin_dt, pin_idx);
+let mut encoder = LinearEncoder::new(pin_clk, pin_dt);
+let mut indexed_encoder = IndexedLinearEncoder::new(pin_clk, pin_dt, pin_idx);
+```
+
+## Async Polling Mode
+
+All encoders support both, blocking as well as non-blocking (i.e. async) polling modes.
+
+To create an async encoder you just have provide the `Async` type parameter:
+
+```rust
+let mut async_encoder: RotaryEncoder<_, _, Async> = RotaryEncoder::new(pin_clk, pin_dt);
+let mut async_indexed_encoder: IndexedRotaryEncoder<_, _, Async> = IndexedRotaryEncoder::new(pin_clk, pin_dt, pin_idx);
+```
+
+Or you can use the `.into_async()` method to convert an existing blocking encoder into a non-blocking one:
+
+```rust
+let mut async_encoder = blocking_encoder.into_async();
+let mut async_indexed_encoder = blocking_indexed_encoder.into_async();
+```
+
+Use the `.into_blocking()` method to convert a non-blocking encoder back into a non-blocking one:
+
+```rust
+let mut blocking_encoder = async_encoder.into_blocking();
+let mut blocking_indexed_encoder = async_indexed_encoder.into_blocking();
 ```
 
 ## Decoding Strategies

--- a/quadrature-encoder/examples/linear.rs
+++ b/quadrature-encoder/examples/linear.rs
@@ -1,15 +1,28 @@
-use embedded_hal_mock::eh1::digital::{
-    Mock as PinMock, State as PinState, Transaction as PinTransaction,
-};
+#[cfg(feature = "eh1")]
+use embedded_hal_mock::eh1::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
+#[cfg(feature = "eh0")]
+use embedded_hal_mock::eh0::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
+#[cfg(feature = "async")]
+use embedded_hal_mock::eh1::digital::Edge;
+#[cfg(feature = "async")]
+use embassy_futures::block_on;
 
 use quadrature_encoder::{LinearEncoder, LinearMovement};
 
 fn main() {
+    #[cfg(not(feature = "async"))]
     let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    #[cfg(not(feature = "async"))]
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
+
+    #[cfg(feature = "async")]
+    let pin_clk = PinMock::new(&[PinTransaction::wait_for_edge(Edge::Any),PinTransaction::get(PinState::High)]);
+    #[cfg(feature = "async")]
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 
     let mut encoder = LinearEncoder::<_, _>::new(pin_clk, pin_dt);
 
+    #[cfg(not(feature = "async"))]
     match encoder.poll() {
         Ok(Some(movement)) => {
             let direction = match movement {
@@ -18,7 +31,19 @@ fn main() {
             };
             println!("Movement detected in {:?} direction.", direction)
         }
-        Ok(None) => println!("No movement detected."),
+        Ok(_) => println!("No movement detected."),
+        Err(error) => println!("Error detected: {:?}.", error),
+    }
+    #[cfg(feature = "async")]
+    match block_on(encoder.poll_async()) {
+        Ok(Some(movement)) => {
+            let direction = match movement {
+                LinearMovement::Forward => "forward",
+                LinearMovement::Backward => "backward",
+            };
+            println!("Movement detected in {:?} direction.", direction)
+        }
+        Ok(_) => println!("No movement detected."),
         Err(error) => println!("Error detected: {:?}.", error),
     }
     println!("Encoder is at position: {:?}.", encoder.position());

--- a/quadrature-encoder/examples/linear.rs
+++ b/quadrature-encoder/examples/linear.rs
@@ -11,12 +11,12 @@ use quadrature_encoder::{LinearEncoder, LinearMovement};
 
 fn main() {
     #[cfg(not(feature = "async"))]
-    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
     #[cfg(not(feature = "async"))]
-    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
 
     #[cfg(feature = "async")]
-    let pin_clk = PinMock::new(&[PinTransaction::wait_for_edge(Edge::Any),PinTransaction::get(PinState::High)]);
+    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::wait_for_edge(Edge::Falling)]);
     #[cfg(feature = "async")]
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 

--- a/quadrature-encoder/examples/linear_async.rs
+++ b/quadrature-encoder/examples/linear_async.rs
@@ -1,3 +1,5 @@
+use embassy_futures::block_on;
+use embedded_hal_mock::eh1::digital::Edge;
 use embedded_hal_mock::eh1::digital::{
     Mock as PinMock, State as PinState, Transaction as PinTransaction,
 };
@@ -7,16 +9,13 @@ use quadrature_encoder::{LinearEncoder, LinearMovement};
 fn main() {
     let pin_clk = PinMock::new(&[
         PinTransaction::get(PinState::High),
-        PinTransaction::get(PinState::High),
+        PinTransaction::wait_for_edge(Edge::Falling),
     ]);
-    let pin_dt = PinMock::new(&[
-        PinTransaction::get(PinState::High),
-        PinTransaction::get(PinState::High),
-    ]);
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 
-    let mut encoder = LinearEncoder::<_, _>::new(pin_clk, pin_dt);
+    let mut encoder = LinearEncoder::<_, _>::new(pin_clk, pin_dt).into_async();
 
-    match encoder.poll() {
+    match block_on(encoder.poll()) {
         Ok(Some(movement)) => {
             let direction = match movement {
                 LinearMovement::Forward => "forward",
@@ -27,7 +26,6 @@ fn main() {
         Ok(_) => println!("No movement detected."),
         Err(error) => println!("Error detected: {:?}.", error),
     }
-
     println!("Encoder is at position: {:?}.", encoder.position());
 
     let (mut pin_clk, mut pin_dt) = encoder.release();

--- a/quadrature-encoder/examples/linear_eh0.rs
+++ b/quadrature-encoder/examples/linear_eh0.rs
@@ -1,7 +1,7 @@
-use embedded_hal_mock::eh1::digital::{
+use embedded_hal_compat::{markers::*, Forward, ForwardCompat};
+use embedded_hal_mock::eh0::digital::{
     Mock as PinMock, State as PinState, Transaction as PinTransaction,
 };
-
 use quadrature_encoder::{LinearEncoder, LinearMovement};
 
 fn main() {
@@ -14,7 +14,12 @@ fn main() {
         PinTransaction::get(PinState::High),
     ]);
 
-    let mut encoder = LinearEncoder::<_, _>::new(pin_clk, pin_dt);
+    let pin_clk_eh1: Forward<embedded_hal_mock::common::Generic<PinTransaction>, ForwardInputPin> =
+        pin_clk.forward();
+    let pin_dt_eh1: Forward<embedded_hal_mock::common::Generic<PinTransaction>, ForwardInputPin> =
+        pin_dt.forward();
+
+    let mut encoder = LinearEncoder::<_, _>::new(pin_clk_eh1, pin_dt_eh1);
 
     match encoder.poll() {
         Ok(Some(movement)) => {
@@ -31,6 +36,6 @@ fn main() {
     println!("Encoder is at position: {:?}.", encoder.position());
 
     let (mut pin_clk, mut pin_dt) = encoder.release();
-    pin_clk.done();
-    pin_dt.done();
+    pin_clk.inner_mut().done();
+    pin_dt.inner_mut().done();
 }

--- a/quadrature-encoder/examples/rotary.rs
+++ b/quadrature-encoder/examples/rotary.rs
@@ -1,15 +1,29 @@
-use embedded_hal_mock::eh1::digital::{
-    Mock as PinMock, State as PinState, Transaction as PinTransaction,
-};
+#[cfg(feature = "eh1")]
+use embedded_hal_mock::eh1::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
+#[cfg(feature = "eh0")]
+use embedded_hal_mock::eh0::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
+#[cfg(feature = "async")]
+use embedded_hal_mock::eh1::digital::Edge;
+#[cfg(feature = "async")]
+use embassy_futures::block_on;
 
 use quadrature_encoder::{RotaryEncoder, RotaryMovement};
 
+
 fn main() {
+    #[cfg(not(feature = "async"))]
     let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    #[cfg(not(feature = "async"))]
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
+
+    #[cfg(feature = "async")]
+    let pin_clk = PinMock::new(&[PinTransaction::wait_for_edge(Edge::Any),PinTransaction::get(PinState::High)]);
+    #[cfg(feature = "async")]
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 
     let mut encoder = RotaryEncoder::<_, _>::new(pin_clk, pin_dt);
 
+    #[cfg(not(feature = "async"))]
     match encoder.poll() {
         Ok(Some(movement)) => {
             let direction = match movement {
@@ -18,9 +32,23 @@ fn main() {
             };
             println!("Movement detected in {:?} direction.", direction)
         }
-        Ok(None) => println!("No movement detected."),
+        Ok(_) => println!("No movement detected."),
         Err(error) => println!("Error detected: {:?}.", error),
     }
+
+    #[cfg(feature = "async")]
+    match block_on(encoder.poll_async()) {
+        Ok(Some(movement)) => {
+            let direction = match movement {
+                RotaryMovement::Clockwise => "clockwise",
+                RotaryMovement::CounterClockwise => "counter-clockwise",
+            };
+            println!("Movement detected in {:?} direction.", direction)
+        }
+        Ok(_) => println!("No movement detected."),
+        Err(error) => println!("Error detected: {:?}.", error),
+    }
+
     println!("Encoder is at position: {:?}.", encoder.position());
 
     let (mut pin_clk, mut pin_dt) = encoder.release();

--- a/quadrature-encoder/examples/rotary.rs
+++ b/quadrature-encoder/examples/rotary.rs
@@ -1,43 +1,22 @@
-#[cfg(feature = "eh1")]
-use embedded_hal_mock::eh1::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
-#[cfg(feature = "eh0")]
-use embedded_hal_mock::eh0::digital::{Mock as PinMock, State as PinState, Transaction as PinTransaction};
-#[cfg(feature = "async")]
-use embedded_hal_mock::eh1::digital::Edge;
-#[cfg(feature = "async")]
-use embassy_futures::block_on;
+use embedded_hal_mock::eh1::digital::{
+    Mock as PinMock, State as PinState, Transaction as PinTransaction,
+};
 
 use quadrature_encoder::{RotaryEncoder, RotaryMovement};
 
-
 fn main() {
-    #[cfg(not(feature = "async"))]
-    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
-    #[cfg(not(feature = "async"))]
-    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
-
-    #[cfg(feature = "async")]
-    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::wait_for_edge(Edge::Falling)]);
-    #[cfg(feature = "async")]
-    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    let pin_clk = PinMock::new(&[
+        PinTransaction::get(PinState::High),
+        PinTransaction::get(PinState::High),
+    ]);
+    let pin_dt = PinMock::new(&[
+        PinTransaction::get(PinState::High),
+        PinTransaction::get(PinState::High),
+    ]);
 
     let mut encoder = RotaryEncoder::<_, _>::new(pin_clk, pin_dt);
 
-    #[cfg(not(feature = "async"))]
     match encoder.poll() {
-        Ok(Some(movement)) => {
-            let direction = match movement {
-                RotaryMovement::Clockwise => "clockwise",
-                RotaryMovement::CounterClockwise => "counter-clockwise",
-            };
-            println!("Movement detected in {:?} direction.", direction)
-        }
-        Ok(_) => println!("No movement detected."),
-        Err(error) => println!("Error detected: {:?}.", error),
-    }
-
-    #[cfg(feature = "async")]
-    match block_on(encoder.poll_async()) {
         Ok(Some(movement)) => {
             let direction = match movement {
                 RotaryMovement::Clockwise => "clockwise",

--- a/quadrature-encoder/examples/rotary.rs
+++ b/quadrature-encoder/examples/rotary.rs
@@ -12,12 +12,12 @@ use quadrature_encoder::{RotaryEncoder, RotaryMovement};
 
 fn main() {
     #[cfg(not(feature = "async"))]
-    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
     #[cfg(not(feature = "async"))]
-    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::get(PinState::High)]);
 
     #[cfg(feature = "async")]
-    let pin_clk = PinMock::new(&[PinTransaction::wait_for_edge(Edge::Any),PinTransaction::get(PinState::High)]);
+    let pin_clk = PinMock::new(&[PinTransaction::get(PinState::High),PinTransaction::wait_for_edge(Edge::Falling)]);
     #[cfg(feature = "async")]
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 

--- a/quadrature-encoder/examples/rotary_async.rs
+++ b/quadrature-encoder/examples/rotary_async.rs
@@ -1,26 +1,24 @@
+use embassy_futures::block_on;
+use embedded_hal_mock::eh1::digital::Edge;
 use embedded_hal_mock::eh1::digital::{
     Mock as PinMock, State as PinState, Transaction as PinTransaction,
 };
-
-use quadrature_encoder::{LinearEncoder, LinearMovement};
+use quadrature_encoder::{RotaryEncoder, RotaryMovement};
 
 fn main() {
     let pin_clk = PinMock::new(&[
         PinTransaction::get(PinState::High),
-        PinTransaction::get(PinState::High),
+        PinTransaction::wait_for_edge(Edge::Falling),
     ]);
-    let pin_dt = PinMock::new(&[
-        PinTransaction::get(PinState::High),
-        PinTransaction::get(PinState::High),
-    ]);
+    let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 
-    let mut encoder = LinearEncoder::<_, _>::new(pin_clk, pin_dt);
+    let mut encoder = RotaryEncoder::<_, _>::new(pin_clk, pin_dt).into_async();
 
-    match encoder.poll() {
+    match block_on(encoder.poll()) {
         Ok(Some(movement)) => {
             let direction = match movement {
-                LinearMovement::Forward => "forward",
-                LinearMovement::Backward => "backward",
+                RotaryMovement::Clockwise => "clockwise",
+                RotaryMovement::CounterClockwise => "counter-clockwise",
             };
             println!("Movement detected in {:?} direction.", direction)
         }

--- a/quadrature-encoder/src/encoder/incremental.rs
+++ b/quadrature-encoder/src/encoder/incremental.rs
@@ -29,7 +29,7 @@ pub struct IncrementalEncoder<Mode, Clk, Dt, Steps = FullStep, T = i32, PM = Blo
     pin_dt_state: bool,
     is_reversed: bool,
     _mode: PhantomData<Mode>,
-    _pollmode: PhantomData<PM>,
+    _poll_mode: PhantomData<PM>,
 }
 
 impl<Mode, Clk, Dt, Steps, T, PM> IncrementalEncoder<Mode, Clk, Dt, Steps, T, PM>
@@ -60,7 +60,7 @@ where
             pin_dt_state,
             is_reversed: false,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }
@@ -181,7 +181,7 @@ where
             pin_dt_state: self.pin_dt_state,
             is_reversed: self.is_reversed,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }
@@ -240,7 +240,7 @@ where
             pin_dt_state: self.pin_dt_state,
             is_reversed: self.is_reversed,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }

--- a/quadrature-encoder/src/encoder/incremental.rs
+++ b/quadrature-encoder/src/encoder/incremental.rs
@@ -5,51 +5,48 @@ use core::marker::PhantomData;
 use num_traits::{One, SaturatingAdd, Zero};
 use quadrature_decoder::{Change, FullStep, IncrementalDecoder, StepMode};
 
-#[cfg(feature="async")]
-use embassy_futures::select::{select,Either};
-#[cfg(feature="async")]
-use futures::FutureExt;
-
 #[allow(unused_imports)]
 use crate::{
-    traits::InputPin,
-    mode::{Movement, OperationMode},
-    Error,Linear, Rotary, InputPinError
+    mode::{Async, Blocking, Movement, OperationMode, PollMode},
+    traits::*,
+    Error, InputPinError, Linear, Rotary,
 };
 
 /// Rotary encoder.
-pub type RotaryEncoder<Clk, Dt, Steps = FullStep, T = i32> =
-    IncrementalEncoder<Rotary, Clk, Dt, Steps, T>;
+pub type RotaryEncoder<Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> =
+    IncrementalEncoder<Rotary, Clk, Dt, Steps, T, PM>;
 /// Linear encoder.
-pub type LinearEncoder<Clk, Dt, Steps = FullStep, T = i32> =
-    IncrementalEncoder<Linear, Clk, Dt, Steps, T>;
+pub type LinearEncoder<Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> =
+    IncrementalEncoder<Linear, Clk, Dt, Steps, T, PM>;
 
 /// A robust incremental encoder with support for multiple step-modes.
 #[derive(Debug)]
-pub struct IncrementalEncoder<Mode, Clk, Dt, Steps = FullStep, T = i32> {
+pub struct IncrementalEncoder<Mode, Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> {
     decoder: IncrementalDecoder<Steps, T>,
     pin_clk: Clk,
     pin_dt: Dt,
-    is_reversed: bool,
-    _mode: PhantomData<Mode>,
     pin_clk_state: bool,
     pin_dt_state: bool,
+    is_reversed: bool,
+    _mode: PhantomData<Mode>,
+    _pollmode: PhantomData<PM>,
 }
 
-impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T>
+impl<Mode, Clk, Dt, Steps, T, PM> IncrementalEncoder<Mode, Clk, Dt, Steps, T, PM>
 where
     Mode: OperationMode,
     Clk: InputPin,
     Dt: InputPin,
     Steps: StepMode,
     T: Zero,
+    PM: PollMode,
 {
     /// Creates an incremental encoder driver for the given pins.
-    /// NOTE: eh1 requires mutable pin references, but eh0 does not, which upsets clippy sometimes.
-    #[allow(unused_mut)]
     pub fn new(mut pin_clk: Clk, mut pin_dt: Dt) -> Self
     where
         IncrementalDecoder<Steps, T>: Default,
+        Clk: InputPin,
+        Dt: InputPin,
     {
         // read the initial pin states to determine starting values
         let pin_clk_state = pin_clk.is_high().unwrap_or(false);
@@ -59,21 +56,23 @@ where
             decoder: Default::default(),
             pin_clk,
             pin_dt,
-            is_reversed: false,
-            _mode: PhantomData,
             pin_clk_state,
             pin_dt_state,
+            is_reversed: false,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
         }
     }
 }
 
-impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T>
+impl<Mode, Clk, Dt, Steps, T, PM> IncrementalEncoder<Mode, Clk, Dt, Steps, T, PM>
 where
     Mode: OperationMode,
     Clk: InputPin,
     Dt: InputPin,
     Steps: StepMode,
     T: Copy + Zero + One + SaturatingAdd + From<i8>,
+    PM: PollMode,
 {
     /// Sets the encoder's reversed mode, making it report flipped movements and positions.
     pub fn reversed(mut self) -> Self {
@@ -96,22 +95,13 @@ where
         (self.pin_clk, self.pin_dt)
     }
 
-    /// Updates the encoder's state based on the given **clock** and **data** pins,
-    /// returning the direction if a movement was detected, `None` if no movement was detected,
-    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
-    ///
-    /// Depending on whether it matters why the encoder did not detect a movement
-    /// (e.g. due to actual lack of movement or an erroneous read)
-    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
-    /// to fall back to `None` in case of `Err(_)`.
-    pub fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
-        #[cfg(not(feature="async"))]
-        {
-        self.pin_clk_state = self.pin_clk.is_high().map_err(|_| Error::InputPin(InputPinError::PinClk))?;
-        self.pin_dt_state = self.pin_dt.is_high().map_err(|_| Error::InputPin(InputPinError::PinDt))?;
-        }
-
-        let change: Option<Change> = self.decoder.update(self.pin_clk_state, self.pin_dt_state).map_err(Error::Quadrature)?;
+    /// Updates the internal decoder state, from the latest IO readings.
+    /// This is called within poll() / poll_async()
+    fn update(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        let change: Option<Change> = self
+            .decoder
+            .update(self.pin_clk_state, self.pin_dt_state)
+            .map_err(Error::Quadrature)?;
         let movement: Option<Mode::Movement> = change.map(From::from);
 
         Ok(movement.map(|movement| {
@@ -121,31 +111,6 @@ where
                 movement
             }
         }))
-    }
-
-    /// Waits asyncronously for either two pins to change state, then runs poll()
-    #[cfg(feature="async")]
-    pub async fn poll_async(&mut self) -> Result<Option<Mode::Movement>, Error> {
-        let clk_fut = match self.pin_clk_state {
-            true => self.pin_clk.wait_for_falling_edge().left_future(),
-            false => self.pin_clk.wait_for_rising_edge().right_future(),
-        };
-
-        let dt_fut = match self.pin_dt_state {
-            true => self.pin_dt.wait_for_falling_edge().left_future(),
-            false => self.pin_dt.wait_for_rising_edge().right_future(),
-        };
-
-        match select(clk_fut, dt_fut).await
-        {
-            Either::First(_) => {
-                self.pin_clk_state = !self.pin_clk_state;
-            },
-            Either::Second(_) => {
-                self.pin_dt_state = !self.pin_dt_state;
-            },
-        };
-        self.poll()
     }
 
     /// Resets the encoder to its initial state.
@@ -161,5 +126,121 @@ where
     /// Sets the encoder's position.
     pub fn set_position(&mut self, position: T) {
         self.decoder.set_counter(position);
+    }
+}
+
+impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Blocking>
+where
+    Mode: OperationMode,
+    Clk: InputPin,
+    Dt: InputPin,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Updates the encoder's state based on the given **clock** and **data** pins,
+    /// returning the direction if a movement was detected, `None` if no movement was detected,
+    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
+    ///
+    /// Depending on whether it matters why the encoder did not detect a movement
+    /// (e.g. due to actual lack of movement or an erroneous read)
+    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
+    /// to fall back to `None` in case of `Err(_)`.
+    pub fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        self.pin_clk_state = self
+            .pin_clk
+            .is_high()
+            .map_err(|_| Error::InputPin(InputPinError::PinClk))?;
+        self.pin_dt_state = self
+            .pin_dt
+            .is_high()
+            .map_err(|_| Error::InputPin(InputPinError::PinDt))?;
+        self.update()
+    }
+}
+
+/// If async is enabled, and the pins provided satisfy the AsyncInputPin trait, the into_async() method is exposed.
+#[cfg(feature = "async")]
+impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Blocking>
+where
+    Mode: OperationMode,
+    Clk: InputPin + Wait,
+    Dt: InputPin + Wait,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Reconfigure the driver so that poll() is an async fn
+    pub fn into_async(self) -> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Async>
+    where
+        IncrementalDecoder<Steps, T>: Default,
+    {
+        IncrementalEncoder::<Mode, Clk, Dt, Steps, T, Async> {
+            decoder: self.decoder,
+            pin_clk: self.pin_clk,
+            pin_dt: self.pin_dt,
+            pin_clk_state: self.pin_clk_state,
+            pin_dt_state: self.pin_dt_state,
+            is_reversed: self.is_reversed,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Async>
+where
+    Mode: OperationMode,
+    Clk: InputPin + Wait,
+    Dt: InputPin + Wait,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Updates the encoder's state based on the given **clock** and **data** pins,
+    /// returning the direction if a movement was detected, `None` if no movement was detected,
+    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
+    ///
+    /// Depending on whether it matters why the encoder did not detect a movement
+    /// (e.g. due to actual lack of movement or an erroneous read)
+    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
+    /// to fall back to `None` in case of `Err(_)`.
+    ///
+    /// Waits asyncronously for any of the pins to change state, before returning.
+    pub async fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        let clk_fut = match self.pin_clk_state {
+            true => self.pin_clk.wait_for_falling_edge().left_future(),
+            false => self.pin_clk.wait_for_rising_edge().right_future(),
+        };
+
+        let dt_fut = match self.pin_dt_state {
+            true => self.pin_dt.wait_for_falling_edge().left_future(),
+            false => self.pin_dt.wait_for_rising_edge().right_future(),
+        };
+
+        match select(clk_fut, dt_fut).await {
+            Either::First(_) => {
+                self.pin_clk_state = !self.pin_clk_state;
+            }
+            Either::Second(_) => {
+                self.pin_dt_state = !self.pin_dt_state;
+            }
+        };
+        self.update()
+    }
+
+    /// Reconfigure the driver so that poll() is a blocking function
+    pub fn into_blocking(self) -> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Blocking>
+    where
+        IncrementalDecoder<Steps, T>: Default,
+    {
+        IncrementalEncoder::<Mode, Clk, Dt, Steps, T, Blocking> {
+            decoder: self.decoder,
+            pin_clk: self.pin_clk,
+            pin_dt: self.pin_dt,
+            pin_clk_state: self.pin_clk_state,
+            pin_dt_state: self.pin_dt_state,
+            is_reversed: self.is_reversed,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
+        }
     }
 }

--- a/quadrature-encoder/src/encoder/incremental.rs
+++ b/quadrature-encoder/src/encoder/incremental.rs
@@ -204,7 +204,7 @@ where
     /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
     /// to fall back to `None` in case of `Err(_)`.
     ///
-    /// Waits asyncronously for any of the pins to change state, before returning.
+    /// Waits asynchronously for any of the pins to change state, before returning.
     pub async fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
         let clk_fut = match self.pin_clk_state {
             true => self.pin_clk.wait_for_falling_edge().left_future(),

--- a/quadrature-encoder/src/encoder/indexed.rs
+++ b/quadrature-encoder/src/encoder/indexed.rs
@@ -31,7 +31,7 @@ pub struct IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps = FullStep, T = i
     pin_idx_state: bool,
     is_reversed: bool,
     _mode: PhantomData<Mode>,
-    _pollmode: PhantomData<PM>,
+    _poll_mode: PhantomData<PM>,
 }
 
 impl<Mode, Clk, Dt, Idx, Steps, T, PM> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, PM>
@@ -63,7 +63,7 @@ where
             pin_idx_state,
             is_reversed: false,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }
@@ -193,7 +193,7 @@ where
             pin_idx_state: self.pin_idx_state,
             is_reversed: self.is_reversed,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }
@@ -264,7 +264,7 @@ where
             pin_idx_state: self.pin_idx_state,
             is_reversed: self.is_reversed,
             _mode: PhantomData,
-            _pollmode: PhantomData,
+            _poll_mode: PhantomData,
         }
     }
 }

--- a/quadrature-encoder/src/encoder/indexed.rs
+++ b/quadrature-encoder/src/encoder/indexed.rs
@@ -5,40 +5,36 @@ use core::marker::PhantomData;
 use num_traits::{One, SaturatingAdd, Zero};
 use quadrature_decoder::{Change, FullStep, IndexedIncrementalDecoder, StepMode};
 
-#[cfg(feature="async")]
-use embassy_futures::select::{select3,Either3};
-#[cfg(feature="async")]
-use futures::FutureExt;
-
 #[allow(unused_imports)]
 use crate::{
-    traits::InputPin,
-    mode::{Movement, OperationMode},
+    mode::{Async, Blocking, Movement, OperationMode, PollMode},
+    traits::*,
     Error, InputPinError, Linear, Rotary,
 };
 
 /// Rotary encoder.
-pub type IndexedRotaryEncoder<Clk, Dt, Steps = FullStep, T = i32> =
-    IndexedIncrementalEncoder<Rotary, Clk, Dt, Steps, T>;
+pub type IndexedRotaryEncoder<Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> =
+    IndexedIncrementalEncoder<Rotary, Clk, Dt, Steps, T, PM>;
 /// Linear encoder.
-pub type IndexedLinearEncoder<Clk, Dt, Steps = FullStep, T = i32> =
-    IndexedIncrementalEncoder<Linear, Clk, Dt, Steps, T>;
+pub type IndexedLinearEncoder<Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> =
+    IndexedIncrementalEncoder<Linear, Clk, Dt, Steps, T, PM>;
 
 /// A robust incremental encoder with support for multiple step-modes.
 #[derive(Debug)]
-pub struct IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps = FullStep, T = i32> {
+pub struct IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps = FullStep, T = i32, PM = Blocking> {
     decoder: IndexedIncrementalDecoder<Steps, T>,
     pin_clk: Clk,
     pin_dt: Dt,
     pin_idx: Idx,
-    is_reversed: bool,
-    _mode: PhantomData<Mode>,
     pin_clk_state: bool,
     pin_dt_state: bool,
     pin_idx_state: bool,
+    is_reversed: bool,
+    _mode: PhantomData<Mode>,
+    _pollmode: PhantomData<PM>,
 }
 
-impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T>
+impl<Mode, Clk, Dt, Idx, Steps, T, PM> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, PM>
 where
     Mode: OperationMode,
     Clk: InputPin,
@@ -46,10 +42,9 @@ where
     Idx: InputPin,
     Steps: StepMode,
     T: Zero,
+    PM: PollMode,
 {
-    /// Creates an indexec incremental encoder driver for the given pins.
-    /// NOTE: eh1 requires mutable pin references, but eh0 does not, which upsets clippy sometimes.
-    #[allow(unused_mut)]
+    /// Creates an indexed incremental encoder driver for the given pins.
     pub fn new(mut pin_clk: Clk, mut pin_dt: Dt, mut pin_idx: Idx) -> Self
     where
         IndexedIncrementalDecoder<Steps, T>: Default,
@@ -63,16 +58,17 @@ where
             pin_clk,
             pin_dt,
             pin_idx,
-            is_reversed: false,
-            _mode: PhantomData,
             pin_clk_state,
             pin_dt_state,
             pin_idx_state,
+            is_reversed: false,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
         }
     }
 }
 
-impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T>
+impl<Mode, Clk, Dt, Idx, Steps, T, PM> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, PM>
 where
     Mode: OperationMode,
     Clk: InputPin,
@@ -80,6 +76,7 @@ where
     Idx: InputPin,
     Steps: StepMode,
     T: Copy + Zero + One + SaturatingAdd + From<i8>,
+    PM: PollMode,
 {
     /// Sets the encoder's reversed mode, making it report flipped movements and positions.
     pub fn reversed(mut self) -> Self {
@@ -102,23 +99,13 @@ where
         (self.pin_clk, self.pin_dt)
     }
 
-    /// Updates the encoder's state based on the given **clock** and **data** pins,
-    /// returning the direction if a movement was detected, `None` if no movement was detected,
-    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
-    ///
-    /// Depending on whether it matters why the encoder did not detect a movement
-    /// (e.g. due to actual lack of movement or an erroneous read)
-    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
-    /// to fall back to `None` in case of `Err(_)`.
-    pub fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
-        #[cfg(not(feature="async"))]
-        {
-        self.pin_clk_state = self.pin_clk.is_high().map_err(|_| Error::InputPin(InputPinError::PinClk))?;
-        self.pin_dt_state = self.pin_dt.is_high().map_err(|_| Error::InputPin(InputPinError::PinDt))?;
-        self.pin_idx_state = self.pin_idx.is_high().map_err(|_| Error::InputPin(InputPinError::PinIdx))?;
-        }
-
-        let change: Option<Change> = self.decoder.update(self.pin_clk_state, self.pin_dt_state, self.pin_idx_state).map_err(Error::Quadrature)?;
+    /// Updates the internal decoder state, from the latest IO readings.
+    /// This is called within poll() / poll_async()
+    fn update(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        let change: Option<Change> = self
+            .decoder
+            .update(self.pin_clk_state, self.pin_dt_state, self.pin_idx_state)
+            .map_err(Error::Quadrature)?;
         let movement: Option<Mode::Movement> = change.map(From::from);
 
         Ok(movement.map(|movement| {
@@ -128,40 +115,6 @@ where
                 movement
             }
         }))
-    }
-
-    /// Waits asyncronously for any of the three pins to change state, then runs poll()
-    #[cfg(feature="async")]
-    pub async fn poll_async(&mut self) -> Result<Option<Mode::Movement>, Error> {
-        let clk_fut = match self.pin_clk_state {
-            true => self.pin_clk.wait_for_falling_edge().left_future(),
-            false => self.pin_clk.wait_for_rising_edge().right_future(),
-        };
-
-        let dt_fut = match self.pin_dt_state {
-            true => self.pin_dt.wait_for_falling_edge().left_future(),
-            false => self.pin_dt.wait_for_rising_edge().right_future(),
-        };
-
-        let idx_fut = match self.pin_idx_state {
-            true => self.pin_idx.wait_for_falling_edge().left_future(),
-            false => self.pin_idx.wait_for_rising_edge().right_future(),
-        };
-
-        match select3(clk_fut,dt_fut,idx_fut).await
-        {
-            Either3::First(_) => {
-                self.pin_clk_state = !self.pin_clk_state;
-            },
-            Either3::Second(_) => {
-                self.pin_dt_state = !self.pin_dt_state;
-            },
-            Either3::Third(_) => {
-                self.pin_idx_state = !self.pin_idx_state;
-            },
-        };
-
-        self.poll()
     }
 
     /// Resets the encoder to its initial state.
@@ -177,5 +130,141 @@ where
     /// Sets the encoder's position.
     pub fn set_position(&mut self, position: T) {
         self.decoder.set_counter(position);
+    }
+}
+
+impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Blocking>
+where
+    Mode: OperationMode,
+    Clk: InputPin,
+    Dt: InputPin,
+    Idx: InputPin,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Updates the encoder's state based on the given **clock**, **data**, and **index** pins,
+    /// returning the direction if a movement was detected, `None` if no movement was detected,
+    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
+    ///
+    /// Depending on whether it matters why the encoder did not detect a movement
+    /// (e.g. due to actual lack of movement or an erroneous read)
+    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
+    /// to fall back to `None` in case of `Err(_)`.
+    pub fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        self.pin_clk_state = self
+            .pin_clk
+            .is_high()
+            .map_err(|_| Error::InputPin(InputPinError::PinClk))?;
+        self.pin_dt_state = self
+            .pin_dt
+            .is_high()
+            .map_err(|_| Error::InputPin(InputPinError::PinDt))?;
+        self.pin_idx_state = self
+            .pin_idx
+            .is_high()
+            .map_err(|_| Error::InputPin(InputPinError::PinIdx))?;
+        self.update()
+    }
+}
+
+/// If async is enabled, and the pins provided satisfy the AsyncInputPin trait, the into_async() method is exposed.
+#[cfg(feature = "async")]
+impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Blocking>
+where
+    Mode: OperationMode,
+    Clk: InputPin + Wait,
+    Dt: InputPin + Wait,
+    Idx: InputPin + Wait,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Reconfigure the driver so that poll() is an async fn
+    pub fn into_async(self) -> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Async>
+    where
+        IndexedIncrementalDecoder<Steps, T>: Default,
+    {
+        IndexedIncrementalEncoder::<Mode, Clk, Dt, Idx, Steps, T, Async> {
+            decoder: self.decoder,
+            pin_clk: self.pin_clk,
+            pin_dt: self.pin_dt,
+            pin_idx: self.pin_idx,
+            pin_clk_state: self.pin_clk_state,
+            pin_dt_state: self.pin_dt_state,
+            pin_idx_state: self.pin_idx_state,
+            is_reversed: self.is_reversed,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Async>
+where
+    Mode: OperationMode,
+    Clk: InputPin + Wait,
+    Dt: InputPin + Wait,
+    Idx: InputPin + Wait,
+    Steps: StepMode,
+    T: Copy + Zero + One + SaturatingAdd + From<i8>,
+{
+    /// Updates the encoder's state based on the given **clock**, **data**, and **index** pins,
+    /// returning the direction if a movement was detected, `None` if no movement was detected,
+    /// or `Err(_)` if an invalid input (i.e. a positional "jump") was detected.
+    ///
+    /// Depending on whether it matters why the encoder did not detect a movement
+    /// (e.g. due to actual lack of movement or an erroneous read)
+    /// you would either call `encoder.poll()` directly, or via `encoder.poll().unwrap_or_default()`
+    /// to fall back to `None` in case of `Err(_)`.
+    ///
+    /// Waits asyncronously for any of the pins to change state, before returning.
+    pub async fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
+        let clk_fut = match self.pin_clk_state {
+            true => self.pin_clk.wait_for_falling_edge().left_future(),
+            false => self.pin_clk.wait_for_rising_edge().right_future(),
+        };
+
+        let dt_fut = match self.pin_dt_state {
+            true => self.pin_dt.wait_for_falling_edge().left_future(),
+            false => self.pin_dt.wait_for_rising_edge().right_future(),
+        };
+
+        let idx_fut = match self.pin_idx_state {
+            true => self.pin_idx.wait_for_falling_edge().left_future(),
+            false => self.pin_idx.wait_for_rising_edge().right_future(),
+        };
+
+        match select3(clk_fut, dt_fut, idx_fut).await {
+            Either3::First(_) => {
+                self.pin_clk_state = !self.pin_clk_state;
+            }
+            Either3::Second(_) => {
+                self.pin_dt_state = !self.pin_dt_state;
+            }
+            Either3::Third(_) => {
+                self.pin_idx_state = !self.pin_idx_state;
+            }
+        };
+
+        self.update()
+    }
+
+    /// Reconfigure the driver so that poll() is a blocking function
+    pub fn into_blocking(self) -> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Blocking>
+    where
+        IndexedIncrementalDecoder<Steps, T>: Default,
+    {
+        IndexedIncrementalEncoder::<Mode, Clk, Dt, Idx, Steps, T, Blocking> {
+            decoder: self.decoder,
+            pin_clk: self.pin_clk,
+            pin_dt: self.pin_dt,
+            pin_idx: self.pin_idx,
+            pin_clk_state: self.pin_clk_state,
+            pin_dt_state: self.pin_dt_state,
+            pin_idx_state: self.pin_idx_state,
+            is_reversed: self.is_reversed,
+            _mode: PhantomData,
+            _pollmode: PhantomData,
+        }
     }
 }

--- a/quadrature-encoder/src/lib.rs
+++ b/quadrature-encoder/src/lib.rs
@@ -3,9 +3,9 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
-mod traits;
 mod encoder;
 mod mode;
+mod traits;
 pub use quadrature_decoder::{Error as QuadratureError, FullStep, HalfStep, QuadStep};
 
 pub use self::{
@@ -13,7 +13,9 @@ pub use self::{
         IncrementalEncoder, IndexedIncrementalEncoder, IndexedLinearEncoder, IndexedRotaryEncoder,
         LinearEncoder, RotaryEncoder,
     },
-    mode::{Linear, LinearMovement, OperationMode, Rotary, RotaryMovement},
+    mode::{
+        Async, Blocking, Linear, LinearMovement, OperationMode, PollMode, Rotary, RotaryMovement,
+    },
 };
 
 /// An error indicating an input pin issue.

--- a/quadrature-encoder/src/lib.rs
+++ b/quadrature-encoder/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
+mod traits;
 mod encoder;
 mod mode;
 pub use quadrature_decoder::{Error as QuadratureError, FullStep, HalfStep, QuadStep};

--- a/quadrature-encoder/src/mode.rs
+++ b/quadrature-encoder/src/mode.rs
@@ -1,6 +1,7 @@
 mod linear;
 mod rotary;
 
+use core::marker::PhantomData;
 use quadrature_decoder::Change;
 
 pub use self::{
@@ -18,3 +19,18 @@ pub trait OperationMode {
     /// The mode's type of movement.
     type Movement: Movement;
 }
+
+/// A marker trait for initializing drivers in a specific mode.
+/// Inspired by https://github.com/esp-rs/esp-hal
+pub trait PollMode {}
+
+/// Driver initialized in blocking mode.
+#[derive(Debug)]
+pub struct Blocking;
+
+/// Driver initialized in async mode.
+#[derive(Debug)]
+pub struct Async(PhantomData<*const ()>);
+
+impl crate::PollMode for Blocking {}
+impl crate::PollMode for Async {}

--- a/quadrature-encoder/src/traits.rs
+++ b/quadrature-encoder/src/traits.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "eh1")]
+use eh1::digital::InputPin as EhalInputPin;
+
+#[cfg(feature = "eh0")]
+use eh0::digital::v2::InputPin as EhalInputPin;
+
+#[cfg(not(feature = "async"))]
+pub trait InputPin: EhalInputPin {}
+#[cfg(not(feature = "async"))]
+impl<T: EhalInputPin> InputPin for T {}
+
+#[cfg(feature = "async")]
+use embedded_hal_async::digital::Wait;
+#[cfg(feature = "async")]
+pub trait InputPin: EhalInputPin + Wait {}
+#[cfg(feature = "async")]
+impl<T: EhalInputPin + Wait> InputPin for T {}

--- a/quadrature-encoder/src/traits.rs
+++ b/quadrature-encoder/src/traits.rs
@@ -1,17 +1,14 @@
-#[cfg(feature = "eh1")]
-use eh1::digital::InputPin as EhalInputPin;
+// Polled pins must impliment ehal v1.0.0 InputPin trait,
+// either directly or via embadded-hal-compat Forward-ing.
+pub use eh1::digital::InputPin;
+use embedded_hal_compat::eh1_0 as eh1;
 
-#[cfg(feature = "eh0")]
-use eh0::digital::v2::InputPin as EhalInputPin;
-
-#[cfg(not(feature = "async"))]
-pub trait InputPin: EhalInputPin {}
-#[cfg(not(feature = "async"))]
-impl<T: EhalInputPin> InputPin for T {}
-
+// exported async traits
 #[cfg(feature = "async")]
-use embedded_hal_async::digital::Wait;
+pub use embassy_futures::select::{select, Either};
 #[cfg(feature = "async")]
-pub trait InputPin: EhalInputPin + Wait {}
+pub use embassy_futures::select::{select3, Either3};
 #[cfg(feature = "async")]
-impl<T: EhalInputPin + Wait> InputPin for T {}
+pub use embedded_hal_async::digital::Wait;
+#[cfg(feature = "async")]
+pub use futures::FutureExt;

--- a/quadrature-encoder/src/traits.rs
+++ b/quadrature-encoder/src/traits.rs
@@ -1,5 +1,5 @@
-// Polled pins must impliment ehal v1.0.0 InputPin trait,
-// either directly or via embadded-hal-compat Forward-ing.
+// Polled pins must implement the `InputPin` trait from embedded-hal v1.0.0,
+// either directly or via `embedded-hal-compat` forward-ing.
 pub use eh1::digital::InputPin;
 use embedded_hal_compat::eh1_0 as eh1;
 


### PR DESCRIPTION
This PR adds a few useful feature flags, resulting from my own usage with the [atsamd](https://github.com/atsamd-rs/atsamd) HAL, which has a mix of `embedded-hal` `v0.2.7` and `v1.0.0` scattered throughout.


<details>
<summary>Original PR text, relevant to first commit only.</summary>

At a high level, the `eh1` and `eh0` features simply change the trait requirement for the encoder pins - using `InputPin`, but from different versions of the `embedded-hal` crate. `eh1` uses v1.0.0, `eh0` uses v0.2.7.

The `async` feature adds the `Wait` trait requirement to the encoder pins, and enables a new `poll_async` function.
This function `select()`s the `wait_for_any_edge()` function on each pin, until an edge is detected, then calls the regular `poll()` function. _I haven't tested this `poll_async()` on any hardware yet - I shall do so in the next 24 hours._ 

I've added a few new dependencies, most are fairly self-explanatory. I chose to use `embassy-futures` instead of the regular `futures` crate because of it's nice `select3` function, and the crate has no further dependencies of it's own, so felt safe.

Thanks for the handy crate!

</details>

## Updated Description 
__...updated on epoch 1737691201__.

After a bit of testing in the wild, I realized that my approach to both `async` and `eh0/eh1` compatibility had a couple fatal flaws:
 1. It wasn't possible to use blocking AND async encoders within the same program, partially due to how the internal `InputPin` trait was affected by the feature flags in use. 
 2. There's really no need to provide `eh0`-compatibility 'from inside the library'. Even though it's 'ugly', I think it's better to rely on a user-wrapped `Forward<Pin>` from the `embedded-hal-compat` crate instead. I've added `rotary_eh0` and `linear_eh0` examples that demonstrates this (although there is probably no need to have both).
 3. The way I had sprinkled `#[cfg(feature = XYZ)]` around resulted in non-additive features, and it was a bit ugly.
 4. It changed the API of `poll()` to `poll_async()`, which is an admittedly a minor change, but one that is inconsistent with how async rust is usually done.
 
To address these shortcomings, I've opted to create an empty `PollMode` marker trait, akin to the `DriverMode` trait in projects such as `esp-hal`'s peripheral drivers. This allows for unique implementations of `poll()` function, depending on this mode, which can be either `Blocking` or `Async`. Common logic for each implementation (updating the `Decoder`) has been moved to a private method `update()`.

Apologies for hacking on this existing PR - it was a bit more of a WIP than I expected.
